### PR TITLE
Extended settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,24 @@ yamaha.isOn(zone)
 yamaha.isOff(zone)
 
 //Volume
-yamaha.setVolumeTo(-500)
+yamaha.setVolumeTo(-500, zone)
 yamaha.volumeUp(50)
 yamaha.volumeDown(50)
 yamaha.muteOn(zone)
 yamaha.muteOff(zone)
+
+//Extended Volume Settings
+yamaha.setBassTo(60)          //-60 to 60 (may depend on model)
+yamaha.setTrebleTo(60)        //-60 to 60 (may depend on model)
+yamaha.setSubwooferTrimTo(60) //-60 to 60 (may depend on model)
+yamaha.setDialogLiftTo(5)     //0 to 5 (may depend on model)
+yamaha.setDialogLevelTo(3)    //0 to 3 (may depend on model)
+yamaha.YPAOVolumeOn()
+yamaha.YPAOVolumeOff()
+yamaha.extraBassOn()
+yamaha.extraBassOff()
+yamaha.adaptiveDRCOn()
+yamaha.adaptiveDRCOff()
 
 //Playback
 yamaha.stop(zone)
@@ -70,8 +83,17 @@ yamaha.getBasicInfo(zone).done(function(basicInfo){
     basicInfo.getCurrentInput();
     basicInfo.isPartyModeEnabled();
     basicInfo.isPureDirectEnabled();
+    basicInfo.getBass();
+    basicInfo.getTreble();
+    basicInfo.getSubwooferTrim();
+    basicInfo.getDialogueLift();
+    basicInfo.getDialogueLevel();
+    basicInfo.getYPAOVolume();
+    basicInfo.getExtraBass();
+    basicInfo.getAdaptiveDRC();
 })
 
+yamaha.isHeadphoneConnected()
 yamaha.getSystemConfig()
 yamaha.getAvailableInputs()
 yamaha.isMenuReady("NET_RADIO")

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ yamaha.getBasicInfo(zone).done(function(basicInfo){
     basicInfo.getSubwooferTrim();
     basicInfo.getDialogueLift();
     basicInfo.getDialogueLevel();
-    basicInfo.getYPAOVolume();
-    basicInfo.getExtraBass();
-    basicInfo.getAdaptiveDRC();
+    basicInfo.isYPAOVolumeEnabled();
+    basicInfo.isExtraBassEnabled();
+    basicInfo.isAdaptiveDRCEnabled();
 })
 
 yamaha.isHeadphoneConnected()

--- a/simpleCommands.js
+++ b/simpleCommands.js
@@ -128,6 +128,72 @@ Yamaha.prototype.setInputTo = function(to, zone){
     return this.SendXMLToReceiver(command);
 };
 
+Yamaha.prototype.setBassTo = function(to){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><Tone><Bass><Val>'+to+'</Val><Exp>1</Exp><Unit>dB</Unit></Bass></Tone></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.setTrebleTo = function(to){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><Tone><Treble><Val>'+to+'</Val><Exp>1</Exp><Unit>dB</Unit></Treble></Tone></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.setSubwooferTrimTo = function(to){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Volume><Subwoofer_Trim><Val>'+to+'</Val><Exp>1</Exp><Unit>dB</Unit></Subwoofer_Trim></Volume></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.setDialogLiftTo = function(to){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><Dialogue_Adjust><Dialogue_Lift>'+to+'</Dialogue_Lift></Dialogue_Adjust></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.setDialogLevelTo = function(to){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><Dialogue_Adjust><Dialogue_Lvl>'+to+'</Dialogue_Lvl></Dialogue_Adjust></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.YPAOVolumeOn = function(){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><YPAO_Volume>Auto</YPAO_Volume></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.YPAOVolumeOff = function(){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><YPAO_Volume>Off</YPAO_Volume></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.extraBassOn = function(){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><Extra_Bass>Auto</Extra_Bass></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.extraBassOff = function(){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><Extra_Bass>Off</Extra_Bass></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.adaptiveDRCOn = function(){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><Adaptive_DRC>Auto</Adaptive_DRC></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
+Yamaha.prototype.adaptiveDRCOff = function(){
+    var zone = getZone(); //only available in Main Zone
+    var command = '<YAMAHA_AV cmd="PUT"><'+zone+'><Sound_Video><Adaptive_DRC>Off</Adaptive_DRC></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command);
+};
+
 Yamaha.prototype.SendXMLToReceiver= function(xml){
 
     var isPutCommand = xml.indexOf("cmd=\"PUT\"">=0);
@@ -148,6 +214,23 @@ Yamaha.prototype.getColor = function()
 {
     return "The receiver is blue";
 };
+
+Yamaha.prototype.isHeadphoneConnected = function(){
+    //checks if a Headphone is connected, returns "Connected" or "Not Connected"
+    //is not available via getBasicInfo, that's why an additional request is needed
+    //only available in Zone 1, this setting is readonly
+    
+    var zone = getZone(1);
+    var command = '<YAMAHA_AV cmd="GET"><'+zone+'><Sound_Video><Headphone>GetParam</Headphone></Sound_Video></'+zone+'></YAMAHA_AV>';
+    return this.SendXMLToReceiver(command).then(xml2js.parseStringAsync).then(function(info){
+        try {
+            return info.YAMAHA_AV[zone][0].Sound_Video[0].Headphone[0];
+        } 
+        catch (e) {
+            return "Not Available"; //if the Receiver has no Headphone Connector
+        }
+    });
+}
 
 Yamaha.prototype.getBasicInfo = function(zone){
 
@@ -186,9 +269,81 @@ function enrichBasicStatus(basicStatus, zone){
         return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Party_Info[0] === "On";
     };
 
+    //the following properties are only available in Main Zone
     basicStatus.isPureDirectEnabled = function(){
-        return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Pure_Direct[0].Mode[0] === "On";
+        try {
+            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Pure_Direct[0].Mode[0] === "On";
+        } catch (e) {
+            return 'Not Available'; 
+        }
     };
+
+    basicStatus.getBass = function(){
+        try {
+            return parseInt(basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Tone[0].Bass[0].Val[0]);
+        } catch (e) {
+            return 0; 
+        }
+    };  
+
+    basicStatus.getTreble = function(){
+        try {
+            return parseInt(basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Tone[0].Treble[0].Val[0]);
+        } catch (e) {
+            return 0; 
+        }
+    };  
+
+    basicStatus.getSubwooferTrim = function(){
+        try {
+            return parseInt(basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Volume[0].Subwoofer_Trim[0].Val[0]);
+        } catch (e) {
+            return 0; 
+        }
+    }; 
+
+    basicStatus.getDialogueLift = function(){
+        try {
+            return parseInt(basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Dialogue_Adjust[0].Dialogue_Lift[0]);
+        } catch (e) {
+            return 0; 
+        }
+    };  
+
+    basicStatus.getDialogueLevel = function(){
+        try {
+            return parseInt(basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Dialogue_Adjust[0].Dialogue_Lvl[0]);
+        } catch (e) {
+            return 0; 
+        }
+    }; 
+
+    basicStatus.getYPAOVolume = function(){
+        //returns 'Off' or 'Auto'
+        try {
+            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].YPAO_Volume[0];
+        } catch (e) {
+            return 'Not Available'; 
+        }
+    };   
+
+    basicStatus.getExtraBass = function(){
+        //returns 'Off' or 'Auto'
+        try {
+            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Extra_Bass[0];
+        } catch (e) {
+            return 'Not Available'; 
+        }
+    }; 
+
+    basicStatus.getAdaptiveDRC = function(){
+        //returns 'Off' or 'Auto'
+        try {
+            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Adaptive_DRC[0];
+        } catch (e) {
+            return 'Not Available'; 
+        }
+    }; 
     return basicStatus;
 }
 
@@ -202,7 +357,7 @@ function addBasicInfoWrapper(basicInfo){
     };
 }
 //TODO: no list, take properties of basicStatus object
-var basicInfos = ["getVolume", "isMuted", "isOn", "isOff", "getCurrentInput","isPartyModeEnabled", "isPureDirectEnabled"];
+var basicInfos = ["getVolume", "isMuted", "isOn", "isOff", "getCurrentInput","isPartyModeEnabled", "isPureDirectEnabled", "getBass"];
 for (var i = 0; i < basicInfos.length; i++) {
     var basicInfo = basicInfos[i];
     addBasicInfoWrapper(basicInfo);

--- a/simpleCommands.js
+++ b/simpleCommands.js
@@ -318,30 +318,30 @@ function enrichBasicStatus(basicStatus, zone){
         }
     }; 
 
-    basicStatus.getYPAOVolume = function(){
-        //returns 'Off' or 'Auto'
+    basicStatus.isYPAOVolumeEnabled = function(){
+        //values 'Off' or 'Auto'
         try {
-            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].YPAO_Volume[0];
+            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].YPAO_Volume[0] !== 'Off';
         } catch (e) {
-            return 'Not Available'; 
+            return false; 
         }
     };   
 
-    basicStatus.getExtraBass = function(){
-        //returns 'Off' or 'Auto'
+    basicStatus.isExtraBassEnabled = function(){
+        //values 'Off' or 'Auto'
         try {
-            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Extra_Bass[0];
+            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Extra_Bass[0] !== 'Off';
         } catch (e) {
-            return 'Not Available'; 
+            return false; 
         }
     }; 
 
-    basicStatus.getAdaptiveDRC = function(){
-        //returns 'Off' or 'Auto'
+    basicStatus.isAdaptiveDRCEnabled = function(){
+        //values 'Off' or 'Auto'
         try {
-            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Adaptive_DRC[0];
+            return basicStatus.YAMAHA_AV[zone][0].Basic_Status[0].Sound_Video[0].Adaptive_DRC[0] !== 'Off';
         } catch (e) {
-            return 'Not Available'; 
+            return false; 
         }
     }; 
     return basicStatus;
@@ -357,7 +357,7 @@ function addBasicInfoWrapper(basicInfo){
     };
 }
 //TODO: no list, take properties of basicStatus object
-var basicInfos = ["getVolume", "isMuted", "isOn", "isOff", "getCurrentInput","isPartyModeEnabled", "isPureDirectEnabled", "getBass"];
+var basicInfos = ["getVolume", "isMuted", "isOn", "isOff", "getCurrentInput","isPartyModeEnabled", "isPureDirectEnabled", "getBass", "getTreble", "getSubwooferTrim", "getDialogueLift", "getDialogueLevel", "isYPAOVolumeEnabled", "isExtraBassEnabled", "isAdaptiveDRCEnabled"];
 for (var i = 0; i < basicInfos.length; i++) {
     var basicInfo = basicInfos[i];
     addBasicInfoWrapper(basicInfo);


### PR DESCRIPTION
Hey, i added many settings of the [original AV Controller App](https://play.google.com/store/apps/details?id=com.yamaha.av.avcontroller).

It's now possible to read and write the following settings:
- bass 
- treble
- subwoofer
- dialogue lift
- dialogue level
- YPAO volume
- extra bass
- adaptive DRC

And it can check if headphones are connected.

All the added settings return 0 or false when they are not present on the av receiver.
I tested them on an Yamaha RX-V679.

PS: I'm using this to set the bass to 0 db (or more) when I'm hearing with headphones and to -6dB when I'm hearing with my big boxes because my neighbor always complains about too much bass.
I intend to integrate the new settings into [ioBroker.yamaha](https://github.com/soef/iobroker.yamaha/blob/master/yamaha.js) to fully automate switching between the different bass levels.
