### PR TITLE
Add support for Scenes and renamed inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,48 @@
 {
-  "name": "yamaha-nodejs",
-  "version": "0.9.4",
-  "description": "An API to control your YAMAHA Receiver written in nodejs",
-  "main": "yamaha.js",
+  "_from": "yamaha-nodejs@>=0.9.0",
+  "_id": "yamaha-nodejs@0.9.4",
+  "_inBundle": false,
+  "_integrity": "sha512-PRMzK7GvZhkSSlnVe5O45TRHjFXVYtb99z0r9N2jOMlFrwmym3FwXeeASOYy0g2yTQVagp9zGY2OMbvzYFT9aQ==",
+  "_location": "/homebridge-yamaha-avr/yamaha-nodejs",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "yamaha-nodejs@>=0.9.0",
+    "name": "yamaha-nodejs",
+    "escapedName": "yamaha-nodejs",
+    "rawSpec": ">=0.9.0",
+    "saveSpec": null,
+    "fetchSpec": ">=0.9.0"
+  },
+  "_requiredBy": [
+    "/homebridge-yamaha-avr"
+  ],
+  "_resolved": "https://registry.npmjs.org/yamaha-nodejs/-/yamaha-nodejs-0.9.4.tgz",
+  "_shasum": "df63ba73f7717be001fde0ad39aeae712a120097",
+  "_spec": "yamaha-nodejs@>=0.9.0",
+  "_where": "/usr/local/lib/node_modules/homebridge-yamaha-avr",
+  "author": {
+    "name": "Pascal Seitz"
+  },
+  "bugs": {
+    "url": "https://github.com/PSeitz/Yamaha-Network-API/issues"
+  },
+  "bundleDependencies": false,
   "dependencies": {
     "bluebird": "^3.3.4",
-    "request": "^2.88.0",
-    "xml2js": "^0.4.16",
     "debug": "^2.2.0",
-    "peer-ssdp": "0.0.5"
+    "peer-ssdp": "0.0.5",
+    "request": "^2.88.0",
+    "xml2js": "^0.4.16"
   },
+  "deprecated": false,
+  "description": "An API to control your YAMAHA Receiver written in nodejs",
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0"
   },
-  "scripts": {
-    "test": "mocha mochatest"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/PSeitz/yamaha-nodejs.git"
-  },
+  "homepage": "https://github.com/PSeitz/Yamaha-Network-API",
   "keywords": [
     "yamaha",
     "api",
@@ -29,10 +51,15 @@
     "receiver",
     "network"
   ],
-  "author": "Pascal Seitz",
   "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/PSeitz/Yamaha-Network-API/issues"
+  "main": "yamaha.js",
+  "name": "yamaha-nodejs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PSeitz/yamaha-nodejs.git"
   },
-  "homepage": "https://github.com/PSeitz/Yamaha-Network-API"
+  "scripts": {
+    "test": "mocha mochatest"
+  },
+  "version": "0.9.4"
 }

--- a/package.json
+++ b/package.json
@@ -1,65 +1,38 @@
 {
-  "_from": "yamaha-nodejs@>=0.9.0",
-  "_id": "yamaha-nodejs@0.9.4",
-  "_inBundle": false,
-  "_integrity": "sha512-PRMzK7GvZhkSSlnVe5O45TRHjFXVYtb99z0r9N2jOMlFrwmym3FwXeeASOYy0g2yTQVagp9zGY2OMbvzYFT9aQ==",
-  "_location": "/homebridge-yamaha-avr/yamaha-nodejs",
-  "_phantomChildren": {},
-  "_requested": {
-    "type": "range",
-    "registry": true,
-    "raw": "yamaha-nodejs@>=0.9.0",
-    "name": "yamaha-nodejs",
-    "escapedName": "yamaha-nodejs",
-    "rawSpec": ">=0.9.0",
-    "saveSpec": null,
-    "fetchSpec": ">=0.9.0"
-  },
-  "_requiredBy": [
-    "/homebridge-yamaha-avr"
-  ],
-  "_resolved": "https://registry.npmjs.org/yamaha-nodejs/-/yamaha-nodejs-0.9.4.tgz",
-  "_shasum": "df63ba73f7717be001fde0ad39aeae712a120097",
-  "_spec": "yamaha-nodejs@>=0.9.0",
-  "_where": "/usr/local/lib/node_modules/homebridge-yamaha-avr",
-  "author": {
-    "name": "Pascal Seitz"
-  },
-  "bugs": {
-    "url": "https://github.com/PSeitz/Yamaha-Network-API/issues"
-  },
-  "bundleDependencies": false,
-  "dependencies": {
-    "bluebird": "^3.3.4",
-    "debug": "^2.2.0",
-    "peer-ssdp": "0.0.5",
-    "request": "^2.88.0",
-    "xml2js": "^0.4.16"
-  },
-  "deprecated": false,
-  "description": "An API to control your YAMAHA Receiver written in nodejs",
-  "devDependencies": {
-    "chai": "^3.5.0",
-    "chai-as-promised": "^5.2.0"
-  },
-  "homepage": "https://github.com/PSeitz/Yamaha-Network-API",
-  "keywords": [
-    "yamaha",
-    "api",
-    "nodejs",
-    "node",
-    "receiver",
-    "network"
-  ],
-  "license": "ISC",
-  "main": "yamaha.js",
-  "name": "yamaha-nodejs",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/PSeitz/yamaha-nodejs.git"
-  },
-  "scripts": {
-    "test": "mocha mochatest"
-  },
-  "version": "0.9.4"
-}
+   "name": "yamaha-nodejs",
+   "version": "0.9.4",
+   "description": "An API to control your YAMAHA Receiver written in nodejs",
+   "main": "yamaha.js",
+   "dependencies": {
+     "bluebird": "^3.3.4",
+     "request": "^2.88.0",
+     "xml2js": "^0.4.16",
+     "debug": "^2.2.0",
+     "peer-ssdp": "0.0.5"
+   },
+   "devDependencies": {
+     "chai": "^3.5.0",
+     "chai-as-promised": "^5.2.0"
+   },
+   "scripts": {
+     "test": "mocha mochatest"
+   },
+   "repository": {
+     "type": "git",
+     "url": "https://github.com/PSeitz/yamaha-nodejs.git"
+   },
+   "keywords": [
+     "yamaha",
+     "api",
+     "nodejs",
+     "node",
+     "receiver",
+     "network"
+   ],
+   "author": "Pascal Seitz",
+   "license": "ISC",
+   "bugs": {
+     "url": "https://github.com/PSeitz/Yamaha-Network-API/issues"
+   },
+   "homepage": "https://github.com/PSeitz/Yamaha-Network-API"
+ }

--- a/simpleCommands.js
+++ b/simpleCommands.js
@@ -343,10 +343,6 @@ Yamaha.prototype.isHeadphoneConnected = function() {
     });
 }
 
-Yamaha.prototype.getCurrentScene = function(zone) {
-
-}
-
 Yamaha.prototype.getBasicInfo = function(zone) {
 
     var command = '<YAMAHA_AV cmd="GET"><' + getZone(zone) + '><Basic_Status>GetParam</Basic_Status></' + getZone(zone) + '></YAMAHA_AV>';

--- a/simpleCommands.js
+++ b/simpleCommands.js
@@ -183,6 +183,11 @@ Yamaha.prototype.setInputTo = function(to, zone) {
     return this.SendXMLToReceiver(command);
 };
 
+Yamaha.prototype.setSceneTo = function(to, zone) {
+   var command = '<YAMAHA_AV cmd="PUT"><' + getZone(zone) + '><Scene><Scene_Sel>Scene ' + to + '</Scene_Sel></Scene></' + getZone(zone) + '></YAMAHA_AV>';
+   return this.SendXMLToReceiver(command);
+}
+
 Yamaha.prototype.remoteCursor = function(cursorKey) {
     // Valid Cursor Commands (case-sensitve):
     // Up, Down, Right, Left, Return, Sel
@@ -336,6 +341,10 @@ Yamaha.prototype.isHeadphoneConnected = function() {
             return "Not Available"; //if the Receiver has no Headphone Connector
         }
     });
+}
+
+Yamaha.prototype.getCurrentScene = function(zone) {
+
 }
 
 Yamaha.prototype.getBasicInfo = function(zone) {
@@ -513,6 +522,16 @@ Yamaha.prototype.getAvailableInputs = function() {
     });
 };
 
+Yamaha.prototype.getAvailableInputsWithNames = function() {
+   return this.getSystemConfig().then(function(info) {
+       var inputs = [];
+       var inputsXML = info.YAMAHA_AV.System[0].Config[0].Name[0];
+       for (var prop in inputsXML) {
+           inputs.push(inputsXML[prop][0]);
+       }
+       return inputs;
+   });
+};
 Yamaha.prototype.selectListItem = function(listname, number) {
     var command = '<YAMAHA_AV cmd="PUT"><' + listname + '><List_Control><Direct_Sel>Line_' + number + '</Direct_Sel></List_Control></' + listname + '></YAMAHA_AV>';
     return this.SendXMLToReceiver(command);


### PR DESCRIPTION
This pull request contains 2 changes:  API to set scenes (self explanatory), and API to get an array of input objects with their friendly names.

When you call getAvailableInputs, the Yamaha receiver (or at least mine) will return a list of renamed inputs.  For example my HDMI1 was renamed AppleTV.  When calling setInputTo it seemed to expect the original name of the input, HDMI1 in this case, and rejected the renamed input of AppleTV.

This exposes the link between original input names and the renamed names